### PR TITLE
pass opts.ecdhCurve through to the https opts.ecdhCurve

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,7 @@ Req.prototype._send = function () {
         opts.ca = this.options.ca;
         opts.ciphers = this.options.ciphers;
         opts.rejectUnauthorized = this.options.rejectUnauthorized;
+        opts.ecdhCurve = this.options.ecdhCurve;
         opts.secureProtocol = this.options.secureProtocol;
     }
     var req = iface.request(opts);


### PR DESCRIPTION
**hyperquest doesn’t pass through option.ecdhCurve to the ‘https’ module**

The https module currently (node 8.6.0 +) has an issue whereby the ecdhCurve doesn’t default to ‘auto’  (https://github.com/nodejs/node/issues/16196).

This can cause certain SSL connections to fail on the handshake (e.g. https://bv.world/feed/) will throw: ‘Error: write EPROTO 140735747584832:error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure’

The issue https://github.com/nodejs/node/issues/16196 states that although this is an issue that has been fixed in Node 9.x, it will not now be fixed in 8.6 + because it is in LTS.  Therefore I need a way to pass this option through hyperquest onto https.